### PR TITLE
Add support for external storages on Android

### DIFF
--- a/scripts/yanu-bootstrap-termux.sh
+++ b/scripts/yanu-bootstrap-termux.sh
@@ -117,12 +117,12 @@ yanu() {
     if [ -d "$HOME/storage/external-1" ]; then
         external_storage_path="$(grep -E '\s/storage/.{4}-.{4}' /proc/mounts | cut -d ' ' -f2)"
 
-        readarray arr <<< "$external_storage_path"
+        readarray -t arr <<< "$external_storage_path"
         external_storage_arr+=( "${arr[@]}" )
     fi
 
     if [ -f "$BINDINGS_PATH" ]; then
-        readarray arr < "$BINDINGS_PATH"
+        readarray -t arr < "$BINDINGS_PATH"
         external_storage_arr+=( "${arr[@]}" )
     fi
 

--- a/scripts/yanu-bootstrap-termux.sh
+++ b/scripts/yanu-bootstrap-termux.sh
@@ -128,7 +128,7 @@ yanu() {
 
     for it in "${external_storage_arr[@]}"; do
         if [ -d "$it" ]; then
-            bind_opts+=( "--bind $it" )
+            bind_opts+=( --bind "$it" )
         fi
     done
 

--- a/scripts/yanu-bootstrap-termux.sh
+++ b/scripts/yanu-bootstrap-termux.sh
@@ -105,11 +105,34 @@ main() {
     cat >"$BIN_DIR/yanu" <<"EOF"
 #!/bin/bash
 
+CFG_DIR="$HOME/.config/com.github.nozwock.yanu"
 YANU_OUT_PATH="$HOME/tmp.com.github.nozwock.yanu.out"
+BINDINGS_PATH="$CFG_DIR/proot-bindings"
 
 # Launch proot yanu
 yanu() {
-    proot-distro login ubuntu-oldlts --bind /storage/emulated/0 --termux-home -- bash -c 'yanu '"$*"" 2> >(tee $YANU_OUT_PATH)"
+    bind_opts=()
+    external_storage_arr=()
+
+    if [ -d "$HOME/storage/external-1" ]; then
+        external_storage_path="$(grep -E '\s/storage/.{4}-.{4}' /proc/mounts | cut -d ' ' -f2)"
+
+        readarray arr <<< "$external_storage_path"
+        external_storage_arr+=( "${arr[@]}" )
+    fi
+
+    if [ -f "$BINDINGS_PATH" ]; then
+        readarray arr < "$BINDINGS_PATH"
+        external_storage_arr+=( "${arr[@]}" )
+    fi
+
+    for it in "${external_storage_arr[@]}"; do
+        if [ -d "$it" ]; then
+            bind_opts+=( "--bind $it" )
+        fi
+    done
+
+    proot-distro login ubuntu-oldlts --termux-home --bind /storage/emulated/0 "${bind_opts[@]}" -- bash -c 'yanu '"$*"" 2> >(tee $YANU_OUT_PATH)"
 }
 
 filter_ansi_codes() {


### PR DESCRIPTION
Fixes #47, Fixes #48

Add logic to get external storage path and bind to it.

In addition, bind to the entries from a new config file located at `$HOME/.config/com.github.nozwock.yanu/proot-bindings`, in case the storage path logic doesn't work for some user.

A user may explicitly bind their external storage like so:
```
# Just an example...
echo '/storage/148F-1F00' >> "$HOME/.config/com.github.nozwock.yanu/proot-bindings"
```
